### PR TITLE
cleaned up the navigation handlers / added single selection on list of page 2 / cleaned up settings and metadata objects

### DIFF
--- a/OpenAerialMap/gui/img_uploader_wizard.py
+++ b/OpenAerialMap/gui/img_uploader_wizard.py
@@ -46,7 +46,7 @@ FORM_CLASS, _ = uic.loadUiType(os.path.join(
 
 class ImgUploaderWizard(QtGui.QWizard, FORM_CLASS):
 
-    def __init__(self, iface, imgSettings, imgMetadata, parent=None):
+    def __init__(self, iface, settings, parent=None):
         """Constructor."""
         super(ImgUploaderWizard, self).__init__(parent)
         # Set up the user interface from Designer.
@@ -79,10 +79,7 @@ class ImgUploaderWizard(QtGui.QWizard, FORM_CLASS):
         self.setButtonText(QtGui.QWizard.CustomButton1, self.tr("&Start upload"));
         self.setOption(QtGui.QWizard.HaveCustomButton1, True);
 
-        """modify this part later!"""
-        #img_settings = QSettings('QGIS','oam-qgis-plugin')
-        self.settings = imgSettings
-        self.metadata = imgMetadata
+        self.settings = settings
 
         self.loadLayers()
         self.loadMetadataSettings()

--- a/OpenAerialMap/gui/img_uploader_wizard.py
+++ b/OpenAerialMap/gui/img_uploader_wizard.py
@@ -56,7 +56,7 @@ class ImgUploaderWizard(QtGui.QWizard, FORM_CLASS):
         # #widgets-and-dialogs-with-auto-connect
         self.iface = iface
         self.setupUi(self)
-        
+
         # Message bars need to be attached to pages, since the wizard object
         # does not have a layout. It doesn't work to attach the same bar
         # object to all pages (it is only shown in the last one). The only way
@@ -93,7 +93,12 @@ class ImgUploaderWizard(QtGui.QWizard, FORM_CLASS):
         self.loadFullMetadata()
 
         # register event handlers
-        # event handling for tab paging - deprecated: wizard already implements it
+        """Reference: List of page navigation buttons in QWizard.
+            Please comment out and implement following functions if necessary."""
+        #self.button(QWizard.BackButton).clicked.connect(self.previousPage)
+        #self.button(QWizard.NextButton).clicked.connect(self.nextPage)
+        #self.button(QWizard.FinishButton).clicked.connect(self.finishWizard)
+        #self.button(QWizard.CancelButton).clicked.connect(self.cancelWizard)
 
         # Imagery connections (wizard page 1)
         self.layers_tool_button.clicked.connect(self.loadLayers)
@@ -102,9 +107,9 @@ class ImgUploaderWizard(QtGui.QWizard, FORM_CLASS):
         self.remove_source_button.clicked.connect(self.removeSources)
         self.up_source_button.clicked.connect(self.upSource)
         self.down_source_button.clicked.connect(self.downSource)
-        #self.imagery_next_button.clicked.connect(self.nextTab)
 
         # Metadata connections (wizard page 2)
+        self.added_sources_list_widget.setSelectionMode(QtGui.QAbstractItemView.SingleSelection)
         self.sense_start_edit.setCalendarPopup(1)
         self.sense_start_edit.setDisplayFormat('dd.MM.yyyy HH:mm')
         self.sense_end_edit.setCalendarPopup(1)
@@ -112,27 +117,13 @@ class ImgUploaderWizard(QtGui.QWizard, FORM_CLASS):
         self.default_button.clicked.connect(self.loadMetadataSettings)
         self.clean_button.clicked.connect(self.cleanMetadataSettings)
         self.save_button.clicked.connect(self.saveMetadata)
-        #self.metadata_next_button.clicked.connect(self.nextTab)
-        #self.metadata_previous_button.clicked.connect(self.previousTab)
 
         # Upload tab connections (wizard page 3)
         self.storage_combo_box.currentIndexChanged.connect(self.enableSpecify)
         self.customButtonClicked.connect(self.startUploader)
-        #self.quit_button.clicked.connect(self.closeDialog)
-        #self.upload_previous_button.clicked.connect(self.previousTab)
 
         #make sure about this function
         #self.exec_()
-
-    #def nextTab(self):
-    #    self.tab_widget.setCurrentIndex(self.tab_widget.currentIndex()+1)
-    #
-    #def previousTab(self):
-    #    self.tab_widget.setCurrentIndex(self.tab_widget.currentIndex()-1)
-    #
-    #def closeDialog(self):
-    #    #return imgSettigs and imgMetadata?
-    #    self.close()
 
     # event handling for imagery tab
     def loadLayers(self):

--- a/OpenAerialMap/gui/img_uploader_wizard.py
+++ b/OpenAerialMap/gui/img_uploader_wizard.py
@@ -81,6 +81,9 @@ class ImgUploaderWizard(QtGui.QWizard, FORM_CLASS):
 
         self.settings = settings
 
+        # Do we need modify this part later?
+        self.metadata = {}
+
         self.loadLayers()
         self.loadMetadataSettings()
         self.loadStorageSettings()

--- a/OpenAerialMap/oam_main.py
+++ b/OpenAerialMap/oam_main.py
@@ -83,14 +83,16 @@ class OpenAerialMap:
         # Declare instance attributes
         self.actions = []
 
-        """make sure if this QSettings object should be belong to
-        the object of OpenAerialMap class"""
+        # need to send this setting object to setting dialog.
         self.settings = QSettings('QGIS','oam-qgis-plugin')
-        self.metadata = {}
+
+        #Testing purpose only
+        #self.settings.remove('')
 
         """this part is only for testImgUploader() function"""
+        """Please delete these statements when we delete the testImgUploader() function"""
         self.currentImgSettings = self.settings
-        self.currentImgMetadata = self.metadata
+        self.currentImgMetadata = {}
 
     # noinspection PyMethodMayBeStatisc
     def tr(self, message):
@@ -182,7 +184,7 @@ class OpenAerialMap:
 
     def displayImgUploaderWizard(self):
 
-        self.imgUploaderWizard = ImgUploaderWizard(self.iface, self.currentImgSettings, self.currentImgMetadata)
+        self.imgUploaderWizard = ImgUploaderWizard(self.iface, self.settings)
         self.imgUploaderWizard.show()
 
     def displaySearchTool(self):


### PR DESCRIPTION
1. deleted and cleaned up the event handlers for page navigation / commented some reference for navigation buttons of QWizard.
2. added single selection restriction on the list of page 2.
3. cleaned up unnecessary settings and metadata objects (unnecessary declaration and data passing between objects).